### PR TITLE
Remove Deface Override on Frontend

### DIFF
--- a/app/overrides/spree/address_checkout.rb
+++ b/app/overrides/spree/address_checkout.rb
@@ -1,7 +1,0 @@
-
-Deface::Override.new(
-  virtual_path: 'spree/checkout/_address',
-  name:         'add validator button to address',
-  insert_before:   '[data-hook="buttons"]',
-  text: "<% if Spree::AvalaraPreference.customer_can_validate.is_true? %><button class='button address_validator'>Validate Ship Address</button><% end %>"
-)


### PR DESCRIPTION
Since Solidus is moving away from Deface, would it be a good idea to at least remove the frontend override so projects can own their implementation of the button? https://github.com/solidusio/solidus/blob/c3a4bcdd213b7d63d125719260b179495dd282f2/CHANGELOG.md#solidus-120-2016-01-26. For us, this override screwed up a lot of our `slim` address template and even disabling it didn't help. Maybe something in the setup wiki or in the readme about putting in the button?