### PR TITLE
Added timeouts to all http calls

### DIFF
--- a/app/models/tax_svc.rb
+++ b/app/models/tax_svc.rb
@@ -53,6 +53,8 @@ class TaxSvc
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http.open_timeout = 1
+      http.read_timeout = 1
 
       res = http.get(uri.request_uri, 'Authorization' => credential, 'Content-Type' => 'application/json')
       JSON.parse(res.body)
@@ -72,6 +74,8 @@ class TaxSvc
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    http.open_timeout = 1
+    http.read_timeout = 1
     res = http.get(uri.request_uri, 'Authorization' => credential)
 
     logger.debug res
@@ -115,7 +119,8 @@ class TaxSvc
 
   def response(uri, request_hash)
     res = RestClient::Request.execute(method: :post,
-                                timeout: 5,
+                                timeout: 1,
+                                open_timeout: 1,
                                 url: service_url + uri,
                                 payload:  JSON.generate(request_hash),
                                 headers: {

--- a/solidus_avatax_certified.gemspec
+++ b/solidus_avatax_certified.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sass-rails"
   s.add_development_dependency "coffee-rails"
   s.add_development_dependency "factory_girl"
-  s.add_development_dependency "selenium-webdriver"
+  s.add_development_dependency "selenium-webdriver", "~> 2.53.4"
   s.add_development_dependency "capybara"
   s.add_development_dependency "capybara-screenshot"
   s.add_development_dependency 'capybara-accessible'


### PR DESCRIPTION
Last year Avatax went down on Black Friday. This caused a lot of
customers to have long checkout times due to the timeouts coming
from Avalara. Lowering the standard read timeout of the restclient
and adding open timeouts will ensure that connections have time
to be established but if there are problems the customer won't
suffer too much.