### PR TITLE
Change from Promotions to non-tax adjustments

### DIFF
--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -29,7 +29,7 @@ module SolidusAvataxCertified
         TaxCode: line_item.tax_category.try(:tax_code) || '',
         ItemCode: line_item.variant.sku,
         Qty: line_item.quantity,
-        Amount: line_item.amount.to_f,
+        Amount: line_item.total.to_f,
         OriginCode: get_stock_location(line_item),
         DestinationCode: 'Dest',
         CustomerUsageType: order.customer_usage_type,
@@ -125,7 +125,7 @@ module SolidusAvataxCertified
     private
 
     def discounted?(line_item)
-      line_item.adjustments.promotion.eligible.any? || order.adjustments.promotion.eligible.any?
+      line_item.adjustments.non_tax.eligible.any? || order.adjustments.non_tax.eligible.any?
     end
 
     def logger

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -60,7 +60,7 @@ Spree::Order.class_eval do
   def avatax_cache_key
     key = ['Spree::Order']
     key << self.number
-    key << self.promo_total
+    key << self.adjustment_total
     key.join('-')
   end
 


### PR DESCRIPTION
Line items can have adjustments that aren't tied to promotions.
This change makes it so those are used when calculating taxes
as well.

I would like some disucussion about this. We are seeing moments when adjust are being created on line items that aren't promotions they are simply adjustments we add to change the price. This PR is intended to allow all adjustments to be taken into account when calculating tax. Is this the right way to do it?