### PR TITLE
Allow adjust! on delivery step

### DIFF
--- a/app/models/solidus_avatax_certified/order_adjuster.rb
+++ b/app/models/solidus_avatax_certified/order_adjuster.rb
@@ -2,7 +2,7 @@ module SolidusAvataxCertified
   class OrderAdjuster < Spree::Tax::OrderAdjuster
 
     def adjust!
-      if %w(cart address delivery).include?(order.state)
+      if %w(cart address).include?(order.state)
         return (order.line_items + order.shipments)
       end
 


### PR DESCRIPTION
If an order has no total the default Solidus state machine will
skip the payment step. This means that the adjust! method won't
call `super` until the user completes the order making the created
tax adjustments unfinalized. For the most part this won't matter
since if the order total is 0 the calculated tax will most likely
be 0 as well but keeping structure and consistency to Solidus'
state_machine seems like idea.