### PR TITLE
Remove ruby 2 3 syntax

### DIFF
--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -159,7 +159,7 @@ module SolidusAvataxCertified
     end
 
     def tax_included_in_price?(item)
-      !!rates_for_item(item).try(:first)&.included_in_price
+      !!rates_for_item(item).try(:first).try(:included_in_price)
     end
   end
 end

--- a/solidus_avatax_certified.gemspec
+++ b/solidus_avatax_certified.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "sass-rails"
   s.add_development_dependency "coffee-rails"
-  s.add_development_dependency "factory_girl"
+  s.add_development_dependency "factory_bot"
   s.add_development_dependency "selenium-webdriver", "~> 2.53.4"
   s.add_development_dependency "capybara"
   s.add_development_dependency "capybara-screenshot"

--- a/spec/controllers/spree/admin/avalara_entity_use_codes_controller_spec.rb
+++ b/spec/controllers/spree/admin/avalara_entity_use_codes_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::Admin::AvalaraEntityUseCodesController do
-  let(:avalara_entity_use_code) { FactoryGirl.create(:avalara_entity_use_code) }
+  let(:avalara_entity_use_code) { FactoryBot.create(:avalara_entity_use_code) }
 
   stub_authorization!
 

--- a/spec/factories/address_hash_factory.rb
+++ b/spec/factories/address_hash_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   # Request Hashes
   factory :address_hash, class: Hash do
     line1 '915 S Jackson St'

--- a/spec/factories/avalara_entity_use_code_factory.rb
+++ b/spec/factories/avalara_entity_use_code_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :avalara_entity_use_code, class: Spree::AvalaraEntityUseCode do
     use_code 'A'
     use_code_description 'Federal government'

--- a/spec/factories/avalara_factories.rb
+++ b/spec/factories/avalara_factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :request_hash, class: Hash do
     createTransactionModel {{
       code: 'R250707809',
@@ -51,7 +51,7 @@ FactoryGirl.define do
   end
 end
 
-FactoryGirl.modify do
+FactoryBot.modify do
   factory :tax_category, class: Spree::TaxCategory do
     name { "TaxCategory - #{rand(999999)}" }
     tax_code { 'PC030000' }

--- a/spec/factories/avalara_order_factory.rb
+++ b/spec/factories/avalara_order_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :avalara_order, class: Spree::Order do
     user
     bill_address

--- a/spec/factories/avalara_shipment_factory.rb
+++ b/spec/factories/avalara_shipment_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :avalara_shipment, class: Spree::Shipment do
     tracking 'U10000'
     cost BigDecimal.new(10)

--- a/spec/factories/avalara_shipping_method_factory.rb
+++ b/spec/factories/avalara_shipping_method_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :avalara_shipping_method, class: Spree::ShippingMethod do
     zones { |a| [Spree::Zone.find_by(name: 'GlobalZone') || create(:zone, :with_country, default_tax: true)] }
     name 'Avalara Ground'

--- a/spec/factories/response_hash_factories.rb
+++ b/spec/factories/response_hash_factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
 
   factory :response_hash_success, class: Hash do
     id 0

--- a/spec/factories/tax_rate_factory.rb
+++ b/spec/factories/tax_rate_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :clothing_tax_rate, class: Spree::TaxRate do
     name 'Tax'
     amount 0.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,7 +53,7 @@ RSpec.configure do |config|
   config.fail_fast = ENV['FAIL_FAST'] || false
   config.order = "random"
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
   config.include Spree::TestingSupport::Preferences
   config.include Spree::TestingSupport::UrlHelpers
   config.include Spree::TestingSupport::ControllerRequests, type: :controller


### PR DESCRIPTION
Edits a line where Ruby 2.3 syntax was used, ass discussed in #82.

I've added an additional commit here to move from FactoryGirl to FactoryBot, as it was necessary to run specs. However, I was unable to get feature specs working locally.