### PR TITLE
Fix Issues with AvaTax Integration

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -1,4 +1,3 @@
-Spree.user_class = "Spree::User"
 Spree::PermittedAttributes.user_attributes.concat([:avalara_entity_use_code_id, :exemption_number, :vat_id])
 Rails.application.config.spree.calculators.tax_rates << Spree::Calculator::AvalaraTransaction
 Spree::Config.tax_adjuster_class = SolidusAvataxCertified::OrderAdjuster

--- a/solidus_avatax_certified.gemspec
+++ b/solidus_avatax_certified.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.requirements << "none"
 
   s.add_dependency "solidus_core", [">= 2.3.0", "< 3.0.0"]
-  s.add_dependency "json", "~> 1.8"
+  s.add_dependency "json", "~> 2.0"
   s.add_dependency "avatax-ruby"
   s.add_dependency "logging", "~> 2.0"
   s.add_dependency "solidus_support"


### PR DESCRIPTION
- We don't use the `Spree::User` class, which this gem forces. We need to remove that configuration line for the app to boot.
- Version 1.8 of the `json` gem is not compatible with the version of Ruby we are using (2.5).