### PR TITLE
Fix factory girl dependency for Solidus < 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,13 +5,24 @@ gem "solidus", github: "solidusio/solidus", branch: branch
 gem "solidus_auth_devise", github: "solidusio/solidus_auth_devise"
 gem 'avatax-ruby'
 
-group :test, :development do
+group :development do
   gem "pry"
 end
 
-gem "rails-controller-testing", group: :test
+if ENV['DB'] == 'mysql'
+  gem 'mysql2'
+else
+  gem 'pg', '~> 0.21'
+end
 
-gem 'pg', '~> 0.21'
-gem 'mysql2'
+group :test do
+  gem 'pry'
+  gem 'rails-controller-testing'
+  if branch < "v2.5"
+    gem 'factory_bot', '4.10.0'
+  else
+    gem 'factory_bot', '> 4.10.0'
+  end
+end
 
 gemspec


### PR DESCRIPTION
We need to load a factory_bot version that has factory_girl in it
to support Solidus versions < 2.5

This change also includes conditional logic for the database
interface gems.