### PR TITLE
Allow json to be version >= 1.8 && < 3.0

### DIFF
--- a/solidus_avatax_certified.gemspec
+++ b/solidus_avatax_certified.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.requirements << "none"
 
   s.add_dependency "solidus_core", [">= 2.3.0", "< 3.0.0"]
-  s.add_dependency "json", "~> 2.0"
+  s.add_dependency "json", [">= 1.8", "< 3.0"]
   s.add_dependency "avatax-ruby"
   s.add_dependency "logging", "~> 2.0"
   s.add_dependency "solidus_support"


### PR DESCRIPTION
After some testing, it seems that the `1.8` version is still compatible with this extension. Lots of extensions still use the 1.x version of the json gem, an upgrade to the 2.x can be a hard task so I think we can allow the older version as far is compatible.

ref #104