### PR TITLE
Fix 'superclass mismatch for Order'

### DIFF
--- a/app/models/spree/avalara_transaction.rb
+++ b/app/models/spree/avalara_transaction.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_dependency 'spree/order'
-
 module Spree
   class AvalaraTransaction < Spree::Base
     belongs_to :order


### PR DESCRIPTION
Fixes an issue with dependency loading that would cause apps to crash with `superclass mismatch for Order`. There is no need for `require_dependency` there as far as I can see, so we can safely remove it.