### PR TITLE
Discount bugfixes

### DIFF
--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -157,7 +157,9 @@ module SolidusAvataxCertified
     end
 
     def discounted?(line_item)
-      line_item.adjustments.promotion.eligible.any? || order.adjustments.promotion.eligible.any?
+      line_item.adjustments.promotion.eligible.any? ||
+        order.adjustments.promotion.eligible.any? ||
+        order.adjustments.where('amount < 0').where(source: nil).eligible.any?
     end
 
     def tax_included_in_price?(item)

--- a/app/models/solidus_avatax_certified/request/get_tax.rb
+++ b/app/models/solidus_avatax_certified/request/get_tax.rb
@@ -5,7 +5,7 @@ module SolidusAvataxCertified
     class GetTax < SolidusAvataxCertified::Request::Base
       def generate
         promotion_discount = order.all_adjustments.promotion.eligible.sum(:amount).abs
-        manual_discount = order.all_adjustments.where(source: nil).eligible.sum(:amount).abs
+        manual_discount = order.all_adjustments.where('amount < 0').where(source: nil).eligible.sum(:amount).abs
 
         {
           createTransactionModel: {


### PR DESCRIPTION
Fixes a couple of issues with discount calculation:

* Positive manual adjustments on the order would be considered as discounts when calculating sales tax
* Manual adjustments on the order would not be taken into consideration when setting the `discounted` property for line items