### PR TITLE
Fix typos in some decorators module names

### DIFF
--- a/app/decorators/models/solidus_avatax_certified/spree/line_item_decorator.rb
+++ b/app/decorators/models/solidus_avatax_certified/spree/line_item_decorator.rb
@@ -2,7 +2,7 @@
 
 module SolidusAvataxCertified
   module Spree
-    module LineItem
+    module LineItemDecorator
       def to_hash
         {
           'Index' => id,

--- a/app/decorators/models/solidus_avatax_certified/spree/order_decorator.rb
+++ b/app/decorators/models/solidus_avatax_certified/spree/order_decorator.rb
@@ -2,7 +2,7 @@
 
 module SolidusAvataxCertified
   module Spree
-    module Order
+    module OrderDecorator
       def self.prepended(base)
         base.has_one :avalara_transaction, dependent: :destroy
 

--- a/app/decorators/models/solidus_avatax_certified/spree/payment_decorator.rb
+++ b/app/decorators/models/solidus_avatax_certified/spree/payment_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module SolidusAvataxCertfied
+module SolidusAvataxCertified
   module Spree
     module PaymentDecorator
       def self.prepended(base)

--- a/app/decorators/models/solidus_avatax_certified/spree/refund_decorator.rb
+++ b/app/decorators/models/solidus_avatax_certified/spree/refund_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module SolidusAvataxCertfied
+module SolidusAvataxCertified
   module Spree
     module RefundDecorator
       def self.prepended(base)


### PR DESCRIPTION
Uniformize decorators' module names and fix a few typos.