### PR TITLE
Deprecate preference seeder

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-SolidusAvataxCertified::PreferenceSeeder.seed!

--- a/lib/solidus_avatax_certified/preference_seeder.rb
+++ b/lib/solidus_avatax_certified/preference_seeder.rb
@@ -4,46 +4,14 @@ module SolidusAvataxCertified
   class PreferenceSeeder
     class << self
       def seed!(print_messages = true)
-        @print_messages = print_messages
-        stored_env_prefs
-        boolean_prefs
-        enabled_countries_pref
-        origin_address
-      end
+        ::Spree::Deprecation.warn(
+          "#{name}#seed! has been deprecated.\n" \
+          "Please refer to our updated setup guide: " \
+          "https://github.com/boomerdigital/solidus_avatax_certified/wiki/Installation"
+        )
 
-      protected
-
-      def stored_env_prefs
-        ::Spree::AvataxConfiguration.storable_env_preferences.each do |env|
-          value = if !ENV["AVATAX_#{env.upcase}"].blank?
-                    ENV["AVATAX_#{env.upcase}"]
-                  end
-
-          ::Spree::Avatax::Config[env.to_sym] = value
-        end
-      end
-
-      def boolean_prefs
-        ::Spree::AvataxConfiguration.boolean_preferences.each do |preference|
-          ::Spree::Avatax::Config[preference.to_sym] = if ['refuse_checkout_address_validation_error', 'log_to_stdout', 'raise_exceptions'].include?(preference)
-                                                       false
-                                                     else
-                                                       true
-                                                     end
-        end
-      end
-
-      def enabled_countries_pref
-        ::Spree::Avatax::Config.address_validation_enabled_countries = ['United States', 'Canada']
-      end
-
-      def origin_address
-        origin = ::Spree::Avatax::Config.origin
-        origin = "{}" if origin.nil?
-      end
-
-      def success_message(name, value)
-        puts "Created: #{name} - #{value || 'Please input value in avalara settings!'}"
+        # maintain the previous behaviour: (re)set the config to default values
+        ::Spree::Avatax::Config.reset
       end
     end
   end

--- a/lib/tasks/load_seeds.rake
+++ b/lib/tasks/load_seeds.rake
@@ -4,11 +4,6 @@ namespace :solidus_avatax_certified do
   desc "Loads seed data."
   task load_seeds: :environment do
     SolidusAvataxCertified::Seeder.seed!
-    SolidusAvataxCertified::PreferenceSeeder.seed!
-  end
-
-  task load_preferences: :environment do
-    SolidusAvataxCertified::PreferenceSeeder.seed!
   end
 
   task load_use_codes: :environment do


### PR DESCRIPTION
Since the preferences aren't persisted to DB anymore, the `PreferenceSeeder.seed!` method was only (re)setting the preferences to their default values.

This deprecates it and removes the `solidus_avatax_certified:load_preferences` rake task.
To avoid breaking existing apps that somehow uses `PreferenceSeeder.seed!`, I preferred to not completely remove it. Instead, if called, it shows now a deprecation message and resets the Avatax preferences to their default values.

(a separate PR deprecating/removing also the `PreferenceUpdater` related logic will follow)

Ref issue: #133

TODO:
- [ ] update wiki