### PR TITLE
Evaluate specific solidus branches in CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,16 +2,18 @@
 
 source "https://rubygems.org"
 
-branch = 'master'
+solidus_branch = ENV.fetch("SOLIDUS_BRANCH", "master")
+
 gem 'avatax-ruby'
-gem "solidus", github: "solidusio/solidus", branch: branch
+
+gem "solidus", github: "solidusio/solidus", branch: solidus_branch
 gem "solidus_auth_devise", github: "solidusio/solidus_auth_devise"
 
 group :test do
-  if branch != 'master' && branch < 'v2.0'
+  if solidus_branch != 'master' && solidus_branch < 'v2.0'
     gem "rails_test_params_backport"
   end
-  if branch < "v2.5"
+  if solidus_branch < "v2.5"
     gem 'factory_bot', '4.10.0'
   else
     gem 'factory_bot', '> 4.10.0'


### PR DESCRIPTION
The Solidus branch was hardcoded to 'master'. No matter what branch was
specified on CI build matrix, it was always testing against Solidus' master branch.