### PR TITLE
Require deface 1.5

### DIFF
--- a/solidus_avatax_certified.gemspec
+++ b/solidus_avatax_certified.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   solidus_version = [">= 2.3.0", "< 3.0.0"]
   s.add_dependency "avatax-ruby"
-  s.add_dependency 'deface'
+  s.add_dependency 'deface', '~> 1.5'
   s.add_dependency "json", "~> 2.0"
   s.add_dependency "logging", "~> 2.0"
   s.add_dependency 'solidus', solidus_version


### PR DESCRIPTION
This PR is going to require deface >= 1.5

`frozen_string_literal: true` in [/app/overrides](https://github.com/boomerdigital/solidus_avatax_certified/blob/master/app/overrides/spree/admin/shared/_configuration_menu.rb#L1) requires deface `~> 1.5`

ref https://github.com/spree/deface/pull/182