### PR TITLE
Fix usage of raise_error without an exception class

### DIFF
--- a/spec/models/tax_svc_spec.rb
+++ b/spec/models/tax_svc_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe TaxSvc, :vcr do
     }
 
     it 'raises error if no transaction_code is passed' do
-      expect { taxsvc.cancel_tax(nil) }.to raise_error
+      expect { taxsvc.cancel_tax(nil) }.to raise_error(ArgumentError, /transaction_code/)
     end
 
     it 'respond with success' do


### PR DESCRIPTION
Using raise_error without passing an exception class or message is dangerous because it effectively swallows all errors, making the test pass. Instead, we should listen for the specific exception we expect the code to raise.