### PR TITLE
Don't redefine admin/users default CRUD routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Spree::Core::Engine.routes.draw do
       get :ping_my_service, :download_avatax_log, :erase_data, :validate_address
     end
 
-    resources :users do
+    resources :users, only: [] do
       member do
         get :avalara_information
         put :avalara_information


### PR DESCRIPTION
When adding `avalara_information` routes for admin/users don't (re)create the default CRUD routes for users.
These routes are placed on the top of the routes table (hence a higher priority) and might cause unexpected conflicts with other routes definitions.