### PR TITLE
Remove solidus_frontend dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,14 @@ orbs:
 
 jobs:
   run-specs-with-postgres:
+    environment:
+      AUTO_RUN_MIGRATIONS: 'true'
     executor: solidusio_extensions/postgres
     steps:
       - solidusio_extensions/run-tests
   run-specs-with-mysql:
+    environment:
+      AUTO_RUN_MIGRATIONS: 'true'
     executor: solidusio_extensions/mysql
     steps:
       - solidusio_extensions/run-tests

--- a/app/decorators/controllers/solidus_avatax_certified/checkout_controller_decorator.rb
+++ b/app/decorators/controllers/solidus_avatax_certified/checkout_controller_decorator.rb
@@ -29,7 +29,7 @@ module SolidusAvataxCertified
         params['address'].permit(:line1, :line2, :city, :postalCode, :country, :region).to_h
       end
 
-      ::Spree::CheckoutController.prepend self
+      ::Spree::CheckoutController.prepend(self) if SolidusAvataxCertified::Engine.frontend_available?
     end
   end
 end

--- a/lib/solidus_avatax_certified.rb
+++ b/lib/solidus_avatax_certified.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
-require 'solidus'
+require 'solidus_api'
+require 'solidus_core'
+require 'solidus_backend'
+
 require 'solidus_support'
 require 'solidus_avatax_certified/engine'
 require 'solidus_avatax_certified/exceptions'

--- a/lib/solidus_avatax_certified/engine.rb
+++ b/lib/solidus_avatax_certified/engine.rb
@@ -17,5 +17,9 @@ module SolidusAvataxCertified
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
     end
+
+    def self.frontend_available?
+      const_defined?('::Spree::Frontend::Engine')
+    end
   end
 end

--- a/solidus_avatax_certified.gemspec
+++ b/solidus_avatax_certified.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_api', solidus_version
   s.add_dependency 'solidus_backend', solidus_version
   s.add_dependency 'solidus_core', solidus_version
-  s.add_dependency 'solidus_support'
+  s.add_dependency 'solidus_support', '0.3.3'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'coffee-rails'

--- a/solidus_avatax_certified.gemspec
+++ b/solidus_avatax_certified.gemspec
@@ -27,7 +27,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'deface', '~> 1.5'
   s.add_dependency 'json', '~> 2.0'
   s.add_dependency 'logging', '~> 2.0'
-  s.add_dependency 'solidus', solidus_version
+  s.add_dependency 'solidus_api', solidus_version
+  s.add_dependency 'solidus_backend', solidus_version
+  s.add_dependency 'solidus_core', solidus_version
   s.add_dependency 'solidus_support'
 
   s.add_development_dependency 'capybara'
@@ -36,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'github_changelog_generator'
+  s.add_development_dependency 'rails-controller-testing'
   s.add_development_dependency 'rspec-rails', '~> 4.0.0.beta2'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'rubocop-rspec'
@@ -45,5 +48,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'webdrivers'
   s.add_development_dependency 'webmock'
-  s.add_development_dependency 'rails-controller-testing'
 end


### PR DESCRIPTION
Thanks for this extension!
The project that I follow uses a custom React frontend + `solidus_api` in place of `solidus_frontend`. We use `solidus_avatax_certified` internally.

With this PR I propose to make this dependency optional.

There's no `require "solidus_frontend"` because I would expect it to be already required in a standard Solidus project using `solidus_frontend`.