### PR TITLE
Make default_environment a class method

### DIFF
--- a/app/models/spree/avatax_configuration.rb
+++ b/app/models/spree/avatax_configuration.rb
@@ -4,7 +4,7 @@ class Spree::AvataxConfiguration < Spree::Preferences::Configuration
   preference :company_code, :string, default: ENV['AVATAX_COMPANY_CODE']
   preference :account, :string, default: ENV['AVATAX_ACCOUNT']
   preference :license_key, :string, default: ENV['AVATAX_LICENSE_KEY']
-  preference :environment, :string, default: -> { default_environment }
+  preference :environment, :string, default: -> { Spree::AvataxConfiguration.default_environment }
   preference :log, :boolean, default: true
   preference :log_to_stdout, :boolean, default: false
   preference :address_validation, :boolean, default: true
@@ -24,7 +24,7 @@ class Spree::AvataxConfiguration < Spree::Preferences::Configuration
     %w(company_code account license_key environment)
   end
 
-  def default_environment
+  def self.default_environment
     if ENV['AVATAX_ENVIRONMENT'].present?
       ENV['AVATAX_ENVIRONMENT']
     else


### PR DESCRIPTION
Since the changes that were made in [this](https://github.com/solidusio/solidus/pull/4064) PR, it was deprecated to use instance methods in the preferences.

In order to make this work as expected, we have added the code into a class method which will be called in the instance method.

