### PR TITLE
Replace Spree.t method removed in Solidus 3.0

### DIFF
--- a/app/decorators/models/solidus_avatax_certified/spree/shipping_rate_decorator.rb
+++ b/app/decorators/models/solidus_avatax_certified/spree/shipping_rate_decorator.rb
@@ -20,8 +20,8 @@ module SolidusAvataxCertified
 
         tax_explanations = taxes.map(&:label).join(tax_label_separator)
 
-        ::Spree.t :display_price_with_explanations,
-          scope: 'shipping_rate.display_price',
+        I18n.t :display_price_with_explanations,
+          scope: 'spree.shipping_rate.display_price',
           price: price,
           explanations: tax_explanations
       end


### PR DESCRIPTION
The Spree.t method was deprecated in Solidus 2.8 [1], and was removed in Solidus 3.0.

1: https://github.com/solidusio/solidus/pull/2915/commits/fc0cdb457be5c5dd65656e708d54a329fb43984e