### PR TITLE
Update configuration to use proc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 solidus_branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 

--- a/app/models/spree/avatax_configuration.rb
+++ b/app/models/spree/avatax_configuration.rb
@@ -4,7 +4,7 @@ class Spree::AvataxConfiguration < Spree::Preferences::Configuration
   preference :company_code, :string, default: ENV['AVATAX_COMPANY_CODE']
   preference :account, :string, default: ENV['AVATAX_ACCOUNT']
   preference :license_key, :string, default: ENV['AVATAX_LICENSE_KEY']
-  preference :environment, :string, default: -> { Spree::AvataxConfiguration.default_environment }
+  preference :environment, :string, default: proc { Spree::AvataxConfiguration.default_environment }
   preference :log, :boolean, default: true
   preference :log_to_stdout, :boolean, default: false
   preference :address_validation, :boolean, default: true


### PR DESCRIPTION
The arity of a proc given as the default for a preference has changed from 0 to 1 on Solidus 3.1. The Solidus version for the loaded preference defaults is given as the proc's argument from this point on.

So we need to change the proc so that it doesn't have lambda semantics (lambdas raise when extra arguments are supplied, while raw procs don't).

Ref: https://github.com/solidusio/solidus/blob/b855247cdd32b556f64552e9933a7c7bb091cda5/core/lib/spree/preferences/preferable_class_methods.rb#L36