### PR TITLE
Fix connection to GitHub over SSH

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 solidus_branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 


### PR DESCRIPTION
Starting from 15 March 2022 it's not possible anymore to connect to GitHub using SSH keys [1] so we need to use https instead.

1: https://github.blog/2021-09-01-improving-git-protocol-security-github/