### PR TITLE
Remove useless requirements from factories

### DIFF
--- a/lib/solidus_avatax_certified/testing_support/factories.rb
+++ b/lib/solidus_avatax_certified/testing_support/factories.rb
@@ -1,7 +1,4 @@
 # frozen_string_literal: true
 
-require 'factory_bot'
-require 'spree/testing_support/factories'
-
 factory_path = "#{File.dirname(__FILE__)}/factories/**/*_factory.rb"
 Dir[factory_path].each { |f| require File.expand_path(f) }


### PR DESCRIPTION
We copied the tests for some models in our project because we wanted to decorate some of them. But running the tests raises an error for a missing factory. We tried to load the factories from the gem but adding require 'solidus_avatax_certified/testing_support/factories' in the rails_helper raises this error:

FactoryBot::DuplicateDefinitionError:
  Sequence already registered: SKU
This happens because the line require 'spree/testing_support/factories' in the gem factories tries to load Solidus factories, but they're already loaded.

Since that requirement is useless, we can safely remove it.