### PR TITLE
Avoid breaking Calculator when `avalara_response` is not a hash

### DIFF
--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -90,6 +90,7 @@ module Spree
 
       return prev_tax_amount if avalara_response.nil?
       return 0 if avalara_response['totalTax'] == 0.0
+      return 0 if avalara_response['lines'].nil?
 
       avalara_response['lines'].each do |line|
         if line['lineNumber'] == "#{item.id}-#{item.avatax_line_code}"


### PR DESCRIPTION
I ran on a scenario where the `avalara_response` would not be `nil` but not be a Hash either when the request failed - causing a cryptic `undefined method :each for nil class` up the stack. It was related to imported Orders that tried to calculate tax with Avalara.

In any case, this is just a naive fix, but it should hopefully save some headache from people that encounter something similar in the future.