### PR TITLE
Adding support for Solidus 4

### DIFF
--- a/solidus_avatax_certified.gemspec
+++ b/solidus_avatax_certified.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  solidus_version = ['>= 2.3.0', '< 4']
+  solidus_version = ['>= 2.3.0', '< 5']
   s.add_dependency 'avatax-ruby'
   s.add_dependency 'deface', '~> 1.5'
   s.add_dependency 'json', '~> 2.0'


### PR DESCRIPTION
This PR updates the gemspec for the Avatax gem to support Solidus 4. This hasn't been thoroughly vetted, but cursory local examination indicates that very little should be impacted here. And at least allowing users to make the choice to update to Solidus 4 seems important.