### PR TITLE
Fix seeder error when used with solidus_globalize

### DIFF
--- a/app/views/spree/admin/avatax_settings/show.html.erb
+++ b/app/views/spree/admin/avatax_settings/show.html.erb
@@ -56,7 +56,7 @@
       <% unless address_validated_countries.nil? %>
       <ul style="list-style: inside;">
         <% address_validated_countries.each do |country| %>
-        <li><%= Spree::Country.find_by_name(country) %></li>
+        <li><%= Spree::Country.find_by(name: country) %></li>
         <% end %>
       </ul>
       <% end %>

--- a/lib/solidus_avatax_certified/seeder.rb
+++ b/lib/solidus_avatax_certified/seeder.rb
@@ -53,7 +53,7 @@ module SolidusAvataxCertified
           shipping_tax.zone = tax_zone
           shipping_tax.show_rate_in_label = false
         end
-        shipping_tax.update!(amount: BigDecimal('0'), zone: ::Spree::Zone.find_by_name('North America'), show_rate_in_label: false, calculator: ::Spree::Calculator::AvalaraTransaction.create!)
+        shipping_tax.update!(amount: BigDecimal('0'), zone: ::Spree::Zone.find_by(name: 'North America'), show_rate_in_label: false, calculator: ::Spree::Calculator::AvalaraTransaction.create!)
       end
 
       def add_tax_category_to_shipping_methods


### PR DESCRIPTION
I had an issue when running `bundle exec rake solidus_avatax_certified:load_seeds` as described in [step 3 of the Installation steps](https://github.com/boomerdigital/solidus_avatax_certified#3-seed-the-db) in the readme.

 I got the following error.

```
/[...]/gems/ruby-3.2.2/gems/activerecord-7.0.7.2/lib/active_record/dynamic_matchers.rb:22:in `method_missing': undefined method `find_by_name' for Spree::Zone:Class (NoMethodError)
```


The reason is that it cannot use the dynamic finder `find_by_name` when that field is overridden with `globalize` gem.

I have the name field of `Spree::Zone` overriden as below.

``` 
module Zone
  def self.prepended(base)
	base.translates :name, :description, fallbacks_for_empty_translations: true
	base.include SolidusGlobalize::Translatable
 	[…]
   end
end
```

I guess there are those who would want to make Zone and Country models translatable with solidus_globalize / globalize.
If there is no particular reason for use the dynamic matcher for these 2 locations, I would like to suggest using the more conventional `find_by(name: <value>)`.