### PR TITLE
Fixing extension for Zeitwerk

### DIFF
--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spree/tax/tax_helpers'
-
 module SolidusAvataxCertified
   class Line
     attr_reader :order, :lines


### PR DESCRIPTION
This PR attempts to fix up the extension for Zeitwerk to make this more compliant with Rails 7.1+. This is all very experimental, so let's see what happens.